### PR TITLE
Remove second app install message

### DIFF
--- a/app/orbit-desktop/src/resolvers/loadAppDefinitionResolvers.ts
+++ b/app/orbit-desktop/src/resolvers/loadAppDefinitionResolvers.ts
@@ -2,13 +2,12 @@ import { getPackageId, requireAppDefinition, updateWorkspacePackageIds } from '@
 import { getGlobalConfig } from '@o/config'
 import { Logger } from '@o/logger'
 import { resolveCommand } from '@o/mediator'
-import { AppDefinitionSetupVerifyCommand, AppInstallToWorkspaceCommand, GetAppStoreAppDefinitionCommand, SpaceEntity, UserEntity, WindowMessageId } from '@o/models'
+import { AppDefinitionSetupVerifyCommand, AppInstallToWorkspaceCommand, GetAppStoreAppDefinitionCommand, SpaceEntity, UserEntity } from '@o/models'
 import { pathExists } from 'fs-extra'
 import { join } from 'path'
 import { getRepository } from 'typeorm'
 
 import { getCurrentWorkspace } from '../helpers/getCurrentWorkspace'
-import { appStatus } from '../managers/AppStatusManager'
 import { commandInstall } from '../WorkspaceManager/commandInstall'
 
 const log = new Logger('app-store-definition-resolvers')
@@ -35,7 +34,7 @@ async function getWorkspaceDirectory() {
 
 function resolveInstallAppToWorkspace() {
   return resolveCommand(AppInstallToWorkspaceCommand, async ({ identifier }) => {
-    appStatus.info(WindowMessageId.install(identifier), `Installing ${identifier}`)
+    log.info(`Installing ${identifier}`)
 
     const directory = await getWorkspaceDirectory()
     const res = await commandInstall({ identifier, directory })


### PR DESCRIPTION
This PR removes the extra install message that hung on the screen that we saw yesterday. I changed it to just log the install message, although even this might be unnecessary.